### PR TITLE
Treat address labels as "const" symbols

### DIFF
--- a/src/assembler.cpp
+++ b/src/assembler.cpp
@@ -460,6 +460,7 @@ void Assembler::handleLabel(std::any const& lbl)
     ::Check(syms.is_redefinable(label), fmt::format("Const Label '{}' cannot be redefined", label));
     // LOGI("Label %s=%x", label, mach->getPC());
     syms.set(label, static_cast<Number>(mach->getPC()));
+    syms.set_final(label);
     if (pendingTest != nullptr) {
         auto* test = pendingTest;
         pendingTest = nullptr;

--- a/src/assembler.cpp
+++ b/src/assembler.cpp
@@ -457,6 +457,7 @@ void Assembler::handleLabel(std::any const& lbl)
             lastLabel = std::any_cast<std::string_view>(lbl);
         }
     }
+    ::Check(syms.is_redefinable(label), fmt::format("Const Label '{}' cannot be redefined", label));
     // LOGI("Label %s=%x", label, mach->getPC());
     syms.set(label, static_cast<Number>(mach->getPC()));
     if (pendingTest != nullptr) {

--- a/src/assembler.cpp
+++ b/src/assembler.cpp
@@ -446,14 +446,12 @@ void Assembler::handleLabel(std::any const& lbl)
     std::string label = std::string(std::any_cast<std::string_view>(lbl));
 
     if (label == "$" || label == "-" || label == "+") {
-        if (inMacro != 0) throw parse_error("No special labels in macro");
+        ::Check(inMacro == 0, "No special labels in macro");
         label = "__special_" + std::to_string(labelNum);
         labelNum++;
     } else {
         if (label[0] == '.') {
-            if (lastLabel.empty()) {
-                throw parse_error("Local label without global label");
-            }
+            ::Check(!lastLabel.empty(), "Local label without global label");
             label = std::string(lastLabel) + label;
         } else {
             lastLabel = std::any_cast<std::string_view>(lbl);
@@ -471,11 +469,8 @@ void Assembler::handleLabel(std::any const& lbl)
                           {"cycles", num(0)}, {"ram", mach->getRam()}};
             syms.set("tests."s + label, res);
         }
-        if (mach->getPC() == test->start) {
-            test->name = label;
-        } else {
-            throw parse_error("No label found after anonymous test");
-        }
+        ::Check(mach->getPC() == test->start, "No label found after anonymous test");
+        test->name = label;
     }
 }
 

--- a/src/assembler.cpp
+++ b/src/assembler.cpp
@@ -257,7 +257,7 @@ std::any Assembler::applyDefine(Macro const& fn, Call const& call)
 
     for (unsigned i = 0; i < call.args.size(); i++) {
         // auto const& v = syms.get(args[i]);
-        if (syms.is_declared(args[i])) {
+        if (syms.is_defined(args[i])) {
             errors.emplace_back(
                 0, 0,
                 fmt::format("Function '{}' shadows global symbol {}", call.name,
@@ -431,7 +431,7 @@ void Assembler::handleLabel(std::any const& lbl)
     if (auto const* p =
             std::any_cast<std::pair<std::string_view, int32_t>>(&lbl)) {
         // Indexed symbol: Label is array of values
-        if (!syms.is_declared(p->first)) {
+        if (!syms.is_defined(p->first)) {
             syms.set(p->first, std::vector<Number>{});
         }
         auto& vec = syms.get<std::vector<Number>>(p->first);
@@ -587,13 +587,13 @@ void Assembler::setupRules()
     parser.after("IfDefDecl", [&](SV& sv) -> std::any {
         ::Check(sv.size() >= 1, "Invalid !ifdef declaration");
         auto s = any_cast<std::string_view>(sv[0]);
-        return Number(syms.is_declared(s));
+        return Number(syms.is_defined(s));
     });
 
     parser.after("IfNDefDecl", [&](SV& sv) -> std::any {
         ::Check(sv.size() >= 1, "Invalid !ifndef declaration");
         auto s = any_cast<std::string_view>(sv[0]);
-        return Number(!syms.is_declared(s));
+        return Number(!syms.is_defined(s));
     });
 
     parser.after("CheckDecl", [&](SV& sv) -> std::any {
@@ -1151,7 +1151,7 @@ void Assembler::setupRules()
         val = syms.get(full);
         // Set undefined numbers to PC, to increase likelihood of
         // correct code generation (less passes)
-        if (val.type() == typeid(Number) && !syms.is_declared(full)) {
+        if (val.type() == typeid(Number) && !syms.is_defined(full)) {
             val = static_cast<Number>(mach->getPC());
         }
         return val;

--- a/src/assembler.cpp
+++ b/src/assembler.cpp
@@ -457,7 +457,7 @@ void Assembler::handleLabel(std::any const& lbl)
             lastLabel = std::any_cast<std::string_view>(lbl);
         }
     }
-    ::Check(syms.is_redefinable(label), fmt::format("Const Label '{}' cannot be redefined", label));
+    ::Check(syms.is_redefinable(label), fmt::format("already defined label '{}'", label));
     // LOGI("Label %s=%x", label, mach->getPC());
     syms.set(label, static_cast<Number>(mach->getPC()));
     syms.set_final(label);

--- a/src/assembler.cpp
+++ b/src/assembler.cpp
@@ -443,7 +443,7 @@ void Assembler::handleLabel(std::any const& lbl)
         return;
     }
 
-    std::string label = std::string(std::any_cast<std::string_view>(lbl));
+    std::string label { std::any_cast<std::string_view>(lbl) };
 
     if (label == "$" || label == "-" || label == "+") {
         ::Check(inMacro == 0, "No special labels in macro");

--- a/src/symbol_table.h
+++ b/src/symbol_table.h
@@ -36,8 +36,6 @@ struct Symbol
     std::any value;
     // This symbol has been read since `clear()`
     bool accessed{false};
-    // This symbol has been defined since `clear()`
-    bool defined{false};
 
     // This symbol is constant and may only be set once.
     bool final{false};
@@ -167,7 +165,6 @@ struct SymbolTable
                 }
             }
             syms[s].value = std::any(val);
-            syms[s].defined = true;
         }
     }
 
@@ -334,7 +331,6 @@ struct SymbolTable
     {
         for (auto& s : syms) {
             s.second.accessed = false;
-            s.second.defined = false;
         }
         accessed.clear();
         undefined.clear();

--- a/src/symbol_table.h
+++ b/src/symbol_table.h
@@ -66,11 +66,6 @@ struct SymbolTable
         return accessed.find(std::string(name)) != accessed.end();
     }
 
-    bool is_declared(std::string_view name) const
-    {
-        return syms.find(std::string(name)) != syms.end();
-    }
-
     bool is_defined(std::string_view name) const
     {
         auto const it = syms.find(std::string(name));

--- a/src/symbol_table.h
+++ b/src/symbol_table.h
@@ -74,6 +74,17 @@ struct SymbolTable
         return defined;
     }
 
+    bool is_redefinable(std::string_view name) const {
+        std::string s {name};
+        auto const it = syms.find(s);
+        if (it != syms.end() && it->second.final) {
+            // symbol exists and marked final
+            return undefined.count(s) > 0;
+        }
+
+        return true;
+    }
+
     void set_sym(std::string_view name, AnyMap const& symbols)
     {
         auto s = std::string(name);

--- a/src/symbol_table.h
+++ b/src/symbol_table.h
@@ -100,7 +100,7 @@ struct SymbolTable
     {
         auto s = std::string(name);
         if (val.type() == typeid(AnyMap)) {
-            set(name, std::any_cast<AnyMap>(val));
+            set_sym(name, std::any_cast<AnyMap>(val));
         } else if (val.type() == typeid(double)) {
             set(name, std::any_cast<double>(val));
         } else {

--- a/src/symbol_table.h
+++ b/src/symbol_table.h
@@ -61,6 +61,11 @@ struct SymbolTable
 
     void acceptUndefined(bool ok) { undef_ok = ok; }
 
+    bool is_accessed(std::string_view name) const
+    {
+        return accessed.find(std::string(name)) != accessed.end();
+    }
+
     bool is_declared(std::string_view name) const
     {
         return syms.find(std::string(name)) != syms.end();

--- a/src/symbol_table.h
+++ b/src/symbol_table.h
@@ -61,7 +61,7 @@ struct SymbolTable
 
     void acceptUndefined(bool ok) { undef_ok = ok; }
 
-    bool is_defined(std::string_view name) const
+    bool is_declared(std::string_view name) const
     {
         return syms.find(std::string(name)) != syms.end();
     }

--- a/src/symbol_table.h
+++ b/src/symbol_table.h
@@ -68,7 +68,14 @@ struct SymbolTable
 
     bool is_defined(std::string_view name) const
     {
-        auto const it = syms.find(std::string(name));
+        std::string s {name};
+        #if 0
+            // TODO: Do we need both the "undefined" set and a "defined" flag?
+            if (undefined.count(s) > 0) {
+                return false;
+            }
+        #endif
+        auto const it = syms.find(s);
         return it != syms.end() ? it->second.defined : false;
     }
 

--- a/src/symbol_table.h
+++ b/src/symbol_table.h
@@ -68,15 +68,12 @@ struct SymbolTable
 
     bool is_defined(std::string_view name) const
     {
+        // A symbol is defined when contained in the "syms" list
+        // and *not* contained in the "undefined" set
         std::string s {name};
-        #if 0
-            // TODO: Do we need both the "undefined" set and a "defined" flag?
-            if (undefined.count(s) > 0) {
-                return false;
-            }
-        #endif
-        auto const it = syms.find(s);
-        return it != syms.end() ? it->second.defined : false;
+        bool defined = undefined.count(s) == 0;
+        defined &= syms.count(s) > 0;
+        return defined;
     }
 
     void set_sym(std::string_view name, AnyMap const& symbols)

--- a/src/symbol_table.h
+++ b/src/symbol_table.h
@@ -66,6 +66,12 @@ struct SymbolTable
         return syms.find(std::string(name)) != syms.end();
     }
 
+    bool is_defined(std::string_view name) const
+    {
+        auto const it = syms.find(std::string(name));
+        return it != syms.end() ? it->second.defined : false;
+    }
+
     void set_sym(std::string_view name, AnyMap const& symbols)
     {
         auto s = std::string(name);

--- a/src/symbol_table.h
+++ b/src/symbol_table.h
@@ -179,6 +179,12 @@ struct SymbolTable
         }
     }
 
+    void set_final(std::string_view name)
+    {
+        std::string s {name};
+        syms[s].final = true;
+    }
+
     // Return a map containing all symbols beginning with
     // name.
     AnyMap collect(std::string_view name) const
@@ -342,6 +348,7 @@ struct SymbolTable
     {
         for (auto& s : syms) {
             s.second.accessed = false;
+            s.second.final = false;
         }
         accessed.clear();
         undefined.clear();

--- a/tests/include.asm
+++ b/tests/include.asm
@@ -2,4 +2,7 @@
 W = 2
 !include "../asm/test_include.i"
 
-!include "../asm/other.i"
+;FIXME: workaround -> "code" label guards from reincluding
+!ifndef code {
+  !include "../asm/other.i"
+}


### PR DESCRIPTION
This PR serves as a basis to check on symbol parsing states during passes. States are:

- ~~declared  -> Symbol has been registered (with or without a value assigned)~~
- accessed -> Symbol is accessed from at least one code location (not necessarily defined)
- defined    -> Symbol is declared and value has been assigned

Other attributes:
- final         -> Symbol is marked constant (redefining it leads to error)
