### PR TITLE
Sort sections by start address when printing

### DIFF
--- a/src/machine.h
+++ b/src/machine.h
@@ -144,6 +144,11 @@ public:
     Section& getSection(std::string const& name);
     Section& getCurrentSection();
     std::deque<Section> const& getSections() const { return sections; }
+    void sortSectionsByStart() {
+        std::sort(sections.begin(), sections.end(), [](auto a, auto b){
+            return a.start < b.start;
+        });
+    }
     uint32_t getPC() const;
     void write(std::string_view name, OutFmt fmt);
     void writeListFile(std::string_view name);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -257,6 +257,7 @@ int main(int argc, char** argv)
     }
 
     if (!state.quiet) {
+        mach.sortSectionsByStart();
         for (auto const& section : mach.getSections()) {
             if (!section.data.empty()) {
                 fmt::print("{:04x}-{:04x} {}\n", section.start,


### PR DESCRIPTION
Before:

```bash
0340-0350 vars
0801-27ff basic_ram
c000-c3ff color_ram
e000-ff3f vram
c400-cf7f r_tables
9000-9fff heightmap_data
0000-001a zp
0801-081d upstart
0900-0905 basic_api
0906-0c6d routines
0c6e-0dff main
0e00-140f s_tables
```

After:

```bash
0000-001a zp
0340-0350 vars
0801-27ff basic_ram
0801-081d upstart
0900-0905 basic_api
0906-0c6d routines
0c6e-0cff main
0d00-130f s_tables
9000-9fff heightmap_data
c000-c3ff color_ram
c400-cf7f r_tables
e000-ff3f vram
```
