### PR TITLE
check SemanticValues for FnCall

### DIFF
--- a/src/assembler.cpp
+++ b/src/assembler.cpp
@@ -668,6 +668,7 @@ void Assembler::setupRules()
     parser.after("MacroCall", [&](SV& sv) { return sv[0]; });
 
     parser.after("FnCall", [&](SV& sv) {
+        ::Check(sv.size() >= 1, "Invalid function call");
         auto call = any_cast<Call>(sv[0]);
         auto name = std::string(call.name);
         bool found = false;


### PR DESCRIPTION
Relates to #22 (transforms crash into exception)

Note this may be valid for any (at least most) of the "Invalid …" exceptions where a cached AST is used.
Those crashes can be worked around by removing `.basscache` directory (forcing a rebuild).
