### PR TITLE
fix for EOT comments

### DIFF
--- a/src/grammar.cpp
+++ b/src/grammar.cpp
@@ -7,7 +7,7 @@ Statement <- Script / MetaBlock / Line
 
 Line <- EndOfLine / NonEmptyLine
 
-NonEmptyLine <- (AssignLine / OpLine / LabelLine / WhiteLine) _ (&'}' / EndOfLine / &EOT)
+NonEmptyLine <- (AssignLine / OpLine / LabelLine / WhiteLine / Comment) _ (&'}' / EndOfLine / &EOT)
 
 WhiteLine <- WS
 

--- a/src/grammar.cpp
+++ b/src/grammar.cpp
@@ -5,13 +5,11 @@ Program <- Statement*
 
 Statement <- Script / MetaBlock / Line
 
-Line <- EndOfLine / NonEmptyLine
+Line <- EndOfLine / NonEmptyLine / CommentLine / WS
 
-NonEmptyLine <- (AssignLine / OpLine / LabelLine / WhiteLine / Comment) _ (&'}' / EndOfLine / &EOT)
+NonEmptyLine <- (AssignLine / OpLine / Label) _ (&'}' EndOfLine)?
 
-WhiteLine <- WS
-
-LabelLine <- Label
+CommentLine <- _ Comment
 
 OpLine <- Label? _ (MacroCall / Instruction)
 

--- a/src/grammar.cpp
+++ b/src/grammar.cpp
@@ -138,8 +138,8 @@ Expression2  <- Atom (Operator Atom)* {
 
 Tern <- '?' DelayedExpression ':' DelayedExpression
 
-Atom <- _? (Star / Unary / Unary2 / Number / String /
-        Index / Lambda / ArrayLiteral / FnCall / Variable / '(' Expression ')') _?
+Atom <- _ (Star / Unary / Unary2 / Number / String /
+        Index / Lambda / ArrayLiteral / FnCall / Variable / '(' Expression ')') _
 
 Star <- '*'
 

--- a/tests/eot.asm
+++ b/tests/eot.asm
@@ -1,0 +1,4 @@
+!include "eot_comment.asm"
+!org 0x1234
+start_of_test:
+    sta $c000

--- a/tests/eot.asm
+++ b/tests/eot.asm
@@ -1,4 +1,7 @@
-!include "eot_comment.asm"
 !org 0x1234
+!include "eot_comment.asm"
+main_var = included_var+1
 start_of_test:
+    !assert included_var == 42, "test failed: included_var differs"
+    !assert main_var == 43; "test failed: main_var differs"
     sta $c000

--- a/tests/eot_comment.asm
+++ b/tests/eot_comment.asm
@@ -1,4 +1,6 @@
+included_var = 0x2a  ; 42
+
 ; ACCU can be checked on 42 (file ends without newline)
-  lda #42
+  lda #included_var
 
 ; comment w/o newline

--- a/tests/eot_comment.asm
+++ b/tests/eot_comment.asm
@@ -1,0 +1,4 @@
+; ACCU can be checked on 42 (file ends without newline)
+  lda #42
+
+; comment w/o newline


### PR DESCRIPTION
Fixes #28

- Adds a test reproducing this -> includes a file with comment directly followed by EOT (no newline).
- Fix grammar rules (`Comment` and related `~EndOfLine`).
