### PR TITLE
Transitional changes to define a common type for nullable values (aka undefined symbols/labels)

### DIFF
--- a/src/assembler.h
+++ b/src/assembler.h
@@ -14,8 +14,6 @@
 
 class Machine;
 
-using AsmValue = std::variant<Number, std::string_view, std::vector<uint8_t>, std::vector<Number>>;
-
 inline void Check(bool v, std::string const& txt)
 {
     if (!v) throw parse_error(txt);

--- a/src/machine.cpp
+++ b/src/machine.cpp
@@ -742,7 +742,7 @@ AsmResult Machine::assemble(Instruction const& instr)
     // Find a matching addressing mode
     auto it_op =
         std::find_if(it_ins->opcodes.begin(), it_ins->opcodes.end(),
-                     [&](auto const& o) { 
+                     [&](auto const& o) {
                         return modeMatches(arg.mode, o.mode, small);
                      });
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -263,10 +263,10 @@ std::any Parser::evaluate(AstNode const& node)
                            sv.name(), ast->line, sv.token_view());
                 for (size_t i = 0; i < sv.size(); i++) {
                     std::any const v = sv[i];
-                    fmt::print("  {}: {}\n", i, any_to_string(v));
+                    fmt::print("  {}: {}\n", i, any_to_string(v, sv.name()));
                 }
                 auto ret = callAction(sv, *ast->action);
-                fmt::print(">>  {}\n", any_to_string(ret));
+                fmt::print(">>  {}\n", any_to_string(ret, sv.name()));
                 return ret;
             }
             return callAction(sv, *ast->action);

--- a/src/parser.h
+++ b/src/parser.h
@@ -67,12 +67,6 @@ public:
 
     AstNode get_node() const { return ast; }
     std::string const& file_name() const;
-
-    template <typename T>
-    T to(size_t i) const
-    {
-        return std::any_cast<T>(operator[](i));
-    }
 };
 
 using ActionFn = std::function<std::any(SemanticValues const&)>;

--- a/src/symbol_table.h
+++ b/src/symbol_table.h
@@ -258,6 +258,7 @@ public:
             }
             undefined.insert(std::string{name});
             if constexpr (std::is_same_v<T, std::any>) {
+                LOGD(fmt::format("Returning zero value for undefined label '{}'\n", name));
                 return zero;
             }
             LOGD("Returning default (%s)", typeid(T{}).name());


### PR DESCRIPTION
:8ball: **Closed** -> collecting the good parts into a new (reviewable) PR #44.

----

# For reference

TBH I don't know how this will turn out, but I think we can replace/enhance our current `using Number = double;` type…

One goal is to simplify bass's state logic and enable it to support more complex features (such as declarative stuff where code blocks can be placed independent of others of the same kind. One concrete example for this is the infamous "move section" use case).

The (obvious) advantage of having a "nullable" type (at runtime) is that we gain an additional state for values during parsing/serialization (`std::any a; if (typeid(a) == typeid(void)) { /* yay, we have found a 'None' value */ }`).

As a rule we can safely say that a label can be accessed before its definition:

```asm
negative_8bit_value = -123  ; NOTE: assignments always hold value! (not an address label)

    lda #-123
    bmi future_label
    lda #42

future_label   ; address label defined (address == PC) at this point
    ; more instructions
    rts
```

As discussed in issue #19, #37, #39 symbols are of constant nature and cannot be (re)defined once they hold a value. (NOTE: As the only exception to this, ACME supports the meta keyword `!set negative_8bit_value = -124` to explicitly set a defined value - rarely used anyway…)

:bulb:
Additionally I suggest adding explicit tests on our parsing rules (expecially "MetaBlock" etc.) to improve the debugging situation and find "unexpected" states of the AST more quickly. At least part of this can be done in this PR (still a hobby project…).