### PR TITLE
Fix type conversions from/to optional type (std::any)

### DIFF
--- a/src/assembler.h
+++ b/src/assembler.h
@@ -14,8 +14,6 @@
 
 class Machine;
 
-using AsmValue = std::variant<Number, std::string_view, std::vector<uint8_t>, std::vector<Number>>;
-
 inline void Check(bool v, std::string const& txt)
 {
     if (!v) throw parse_error(txt);

--- a/src/machine.cpp
+++ b/src/machine.cpp
@@ -742,7 +742,7 @@ AsmResult Machine::assemble(Instruction const& instr)
     // Find a matching addressing mode
     auto it_op =
         std::find_if(it_ins->opcodes.begin(), it_ins->opcodes.end(),
-                     [&](auto const& o) { 
+                     [&](auto const& o) {
                         return modeMatches(arg.mode, o.mode, small);
                      });
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -263,10 +263,10 @@ std::any Parser::evaluate(AstNode const& node)
                            sv.name(), ast->line, sv.token_view());
                 for (size_t i = 0; i < sv.size(); i++) {
                     std::any const v = sv[i];
-                    fmt::print("  {}: {}\n", i, any_to_string(v));
+                    fmt::print("  {}: {}\n", i, any_to_string(v, sv.name()));
                 }
                 auto ret = callAction(sv, *ast->action);
-                fmt::print(">>  {}\n", any_to_string(ret));
+                fmt::print(">>  {}\n", any_to_string(ret, sv.name()));
                 return ret;
             }
             return callAction(sv, *ast->action);

--- a/src/parser.h
+++ b/src/parser.h
@@ -67,12 +67,6 @@ public:
 
     AstNode get_node() const { return ast; }
     std::string const& file_name() const;
-
-    template <typename T>
-    T to(size_t i) const
-    {
-        return std::any_cast<T>(operator[](i));
-    }
 };
 
 using ActionFn = std::function<std::any(SemanticValues const&)>;

--- a/src/symbol_table.h
+++ b/src/symbol_table.h
@@ -258,6 +258,7 @@ public:
             }
             undefined.insert(std::string{name});
             if constexpr (std::is_same_v<T, std::any>) {
+                LOGD(fmt::format("Returning zero value for undefined label '{}'\n", name));
                 return zero;
             }
             LOGD("Returning default (%s)", typeid(T{}).name());


### PR DESCRIPTION
NOTE: Does not change current parsing logic!

- Throw on invalid conversion of an empty std::any value to non-optional (c++) type (int,Number,string,…)
- Remove (unused) SemanticValues array value cast function
- Move definition of `AsmValue` type to `defines.h` (-> less dependent code units)