### PR TITLE
Make section start "nullable" (represented by std::nullopt)

### DIFF
--- a/src/assembler.cpp
+++ b/src/assembler.cpp
@@ -1329,13 +1329,13 @@ bool Assembler::parse(std::string_view source, std::string const& fname)
         auto layoutOk = mach->layoutSections();
 
         for (auto const& s : mach->getSections()) {
-            LOGD("%s : %x -> %x (%d) [%x]\n", s.name, s.start, s.start + s.size,
+            LOGD("%s : %x -> %x (%d) [%x]\n", s.name, s.start.value(), s.start.value() + s.size.value(),
                  s.data.size(), s.flags);
 
             auto prefix = "section."s + std::string(s.name);
 
-            auto start = static_cast<Number>(s.start);
-            auto end = static_cast<Number>(s.start + s.data.size());
+            auto start = static_cast<Number>(s.start.value());
+            auto end = static_cast<Number>(s.start.value() + s.data.size());
 
             syms.set(prefix + ".start", start);
             syms.set(prefix + ".end", end);

--- a/src/defines.h
+++ b/src/defines.h
@@ -6,6 +6,7 @@
 #include <coreutils/file.h>
 #include <fmt/format.h>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -110,6 +111,15 @@ inline std::string_view operator+(std::string_view sv, std::string_view n)
 }
 
 using Number = double;
+
+template<typename T>
+using Optional = std::optional<T>;
+// TODO: register type for RTTI comparison (aka std::type_info)
+// struct Optional : public std::optional<T> {
+//     Optional() : std::optional<T>() {
+//         // TODO: register type for RTTI comparison (aka std::typeinfo)
+//     }
+// };
 
 inline Num div(Num a, Num b)
 {

--- a/src/machine.cpp
+++ b/src/machine.cpp
@@ -216,9 +216,8 @@ void Machine::removeSection(std::string const& name)
 // Layout section 's', exactly at address if Floating, otherwise
 // it must at least be placed after address
 // Return section end
-int32_t Machine::layoutSection(Optional<int32_t> const& o_start, Section& s)
+int32_t Machine::layoutSection(int32_t start, Section& s)
 {
-    auto start = o_start.value();
     if (!s.valid) {
         LOGI("Skipping invalid section %s", s.name);
         return start;

--- a/src/machine.cpp
+++ b/src/machine.cpp
@@ -162,7 +162,7 @@ Section& Machine::addSection(Section const& s)
 
     if (!in.empty()) {
         auto& parent = getSection(in);
-        LOGD("Parent %s at %x/%x", parent.name, parent.start, parent.pc);
+        LOGD("Parent %s at %x/%x", parent.name, parent.start.value(), parent.pc.value());
         Check(parent.data.empty(), "Parent section must contain no data");
 
         if (section.parent.empty()) {
@@ -175,7 +175,7 @@ Section& Machine::addSection(Section const& s)
         }
 
         if (section.start == -1) {
-            LOGD("Setting start to %x", parent.pc);
+            LOGD("Setting start to %x", parent.pc.value());
             section.start = parent.pc;
         }
     }
@@ -216,8 +216,9 @@ void Machine::removeSection(std::string const& name)
 // Layout section 's', exactly at address if Floating, otherwise
 // it must at least be placed after address
 // Return section end
-int32_t Machine::layoutSection(int32_t start, Section& s)
+int32_t Machine::layoutSection(Optional<int32_t> const& o_start, Section& s)
 {
+    auto start = o_start.value();
     if (!s.valid) {
         LOGI("Skipping invalid section %s", s.name);
         return start;
@@ -226,7 +227,7 @@ int32_t Machine::layoutSection(int32_t start, Section& s)
     LOGD("Layout %s", s.name);
     if ((s.flags & FixedStart) == 0) {
         if (s.start != start) {
-            LOGD("%s: %x differs from %x", s.name, s.start, start);
+            LOGD("%s: %x differs from %x", s.name, s.start.value(), start);
             layoutOk = false;
         }
         s.start = start;
@@ -234,12 +235,12 @@ int32_t Machine::layoutSection(int32_t start, Section& s)
 
     Check(s.start >= start,
           fmt::format("Section {} starts at {:x} which is before {:x}", s.name,
-                      s.start, start));
+                      s.start.value(), start));
 
     if (!s.data.empty()) {
         Check(s.children.empty(), "Data section may not have children");
         // Leaf / data section
-        return s.start + static_cast<int32_t>(s.data.size());
+        return s.start.value() + static_cast<int32_t>(s.data.size());
     }
 
     if (!s.children.empty()) {
@@ -250,12 +251,12 @@ int32_t Machine::layoutSection(int32_t start, Section& s)
     }
     // Unless fixed size, update size to total of its children
     if ((s.flags & FixedSize) == 0) {
-        s.size = start - s.start;
+        s.size = start - s.start.value();
     }
-    if (start - s.start > s.size) {
+    if (start - s.start.value() > s.size) {
         throw machine_error(fmt::format("Section {} is too large", s.name));
     }
-    return s.start + s.size;
+    return s.start.value() + s.size.value();
 }
 
 bool Machine::layoutSections()
@@ -265,7 +266,7 @@ bool Machine::layoutSections()
     for (auto& s : sections) {
         if (s.parent.empty()) {
             // LOGI("Root %s at %x", s.name, s.start);
-            auto start = s.start;
+            auto start = s.start.value();
             layoutSection(start, s);
         }
     }
@@ -279,9 +280,9 @@ Error Machine::checkOverlap()
             for (auto const& b : sections) {
                 if (&a != &b && !b.data.empty() &&
                     ((b.flags & NoStorage) == 0)) {
-                    auto as = a.start;
+                    auto as = a.start.value();
                     auto ae = as + static_cast<int32_t>(a.data.size());
-                    auto bs = b.start;
+                    auto bs = b.start.value();
                     auto be = bs + static_cast<int32_t>(b.data.size());
                     if (as >= bs && as < be) {
                         return {2, 0,
@@ -353,7 +354,7 @@ uint32_t Machine::getPC() const
     if (currentSection == nullptr) {
         return 0;
     }
-    return currentSection->pc;
+    return currentSection->pc.value();
 }
 
 // clang-format off
@@ -411,9 +412,9 @@ void Machine::writeCrt(utils::File const& outFile)
         if (section.data.empty()) {
             continue;
         }
-        LOGI("Start %x", section.start);
-        auto bank = section.start >> 16;
-        auto start = section.start & 0xffff;
+        LOGI("Start %x", section.start.value());
+        auto bank = section.start.value() >> 16;
+        auto start = section.start.value() & 0xffff;
         auto end = start + section.data.size();
         // bank : 01a000,01c000,01e000
         if (start < 0x8000 || end > 0xc000) {
@@ -493,8 +494,8 @@ void Machine::write(std::string_view name, OutFmt fmt)
 
     utils::File outFile = createFile(name);
 
-    auto start = non_empty.front().start;
-    auto end = non_empty.back().start +
+    auto start = non_empty.front().start.value();
+    auto end = non_empty.back().start.value() +
                static_cast<int32_t>(non_empty.back().data.size());
 
     if (end <= start) {
@@ -535,8 +536,8 @@ void Machine::write(std::string_view name, OutFmt fmt)
         }
         if ((section.flags & WriteToDisk) != 0) {
             auto of = createFile(section.name);
-            of.write<uint8_t>(section.start & 0xff);
-            of.write<uint8_t>(section.start >> 8);
+            of.write<uint8_t>(section.start.value() & 0xff);
+            of.write<uint8_t>(section.start.value() >> 8);
             of.write(section.data);
             of.close();
             continue;
@@ -554,7 +555,7 @@ void Machine::write(std::string_view name, OutFmt fmt)
                 fmt::format("Section {} overlaps previous", section.name));
         }
 
-        auto offset = section.start;
+        auto offset = section.start.value();
 
         if (last_end >= 0) {
             while (last_end < offset) {
@@ -613,12 +614,12 @@ std::pair<uint32_t, uint32_t> Machine::runSetup()
                 continue;
             }
             if (low == 0) {
-                low = section.start;
+                low = section.start.value();
             }
-            high = section.start + section.data.size();
+            high = section.start.value() + section.data.size();
             //LOGI("Writing '%s' to %x-%x", section.name, section.start,
             //     section.start + section.data.size());
-            machine->write_ram(section.start, section.data.data(),
+            machine->write_ram(section.start.value(), section.data.data(),
                                section.data.size());
         }
     }
@@ -628,18 +629,20 @@ std::pair<uint32_t, uint32_t> Machine::runSetup()
 
 uint32_t Machine::writeByte(uint8_t b)
 {
-    dis[currentSection->pc] = fmt::format("{:02x}", b);
+    auto& section_pc = currentSection->pc;
+    dis[section_pc.value()] = fmt::format("{:02x}", b);
     currentSection->data.push_back(b);
-    currentSection->pc++;
-    return currentSection->pc;
+    section_pc.emplace(section_pc.value() + 1);
+    return section_pc.value();
 }
 
 uint32_t Machine::writeChar(uint8_t b)
 {
-    dis[currentSection->pc] = fmt::format("{:02x}", b);
+    auto& section_pc = currentSection->pc;
+    dis[section_pc.value()] = fmt::format("{:02x}", b);
     currentSection->data.push_back(b);
-    currentSection->pc++;
-    return currentSection->pc;
+    section_pc.emplace(section_pc.value() + 1);
+    return section_pc.value();
 }
 
 std::string Machine::disassemble(sixfive::Machine<EmuPolicy>& m, uint32_t* pc)
@@ -752,13 +755,13 @@ AsmResult Machine::assemble(Instruction const& instr)
     arg.mode = it_op->mode;
 
     if (arg.mode == Mode::REL) {
-        arg.val = arg.val - currentSection->pc - 2;
+        arg.val = arg.val - currentSection->pc.value() - 2;
     }
 
     if (arg.mode == Mode::ZP_REL) {
         auto adr = arg.val & 0xffff;
         auto val = (arg.val >> 16) & 0xff;
-        auto diff = adr - currentSection->pc - 2;
+        auto diff = adr - currentSection->pc.value() - 2;
         arg.val = diff << 8 | val;
     }
 
@@ -767,22 +770,22 @@ AsmResult Machine::assemble(Instruction const& instr)
     auto& cs = *currentSection;
     auto v = arg.val & (sz == 2 ? 0xff : 0xffff);
     if (arg.mode == sixfive::Mode::REL) {
-        v = (static_cast<int8_t>(v)) + 2 + cs.pc;
+        v = (static_cast<int8_t>(v)) + 2 + cs.pc.value();
     }
 
-    dis[cs.pc] = fmt::format(
+    dis[cs.pc.value()] = fmt::format(
         "{} "s + modeTemplate.at(static_cast<int>(arg.mode)), it_ins->name, v);
 
     cs.data.push_back(it_op->code);
     if (sz > 1) {
         cs.data.push_back(arg.val & 0xff);
-        dis.erase(cs.pc + 1);
+        dis.erase(cs.pc.value() + 1);
     }
     if (sz > 2) {
         cs.data.push_back(arg.val >> 8);
-        dis.erase(cs.pc + 2);
+        dis.erase(cs.pc.value() + 2);
     }
-    cs.pc += sz;
+    cs.pc.emplace(cs.pc.value() + sz);
 
     if (arg.mode == Mode::REL && (arg.val > 127 || arg.val < -128)) {
         return AsmResult::Truncated;

--- a/src/machine.h
+++ b/src/machine.h
@@ -77,7 +77,7 @@ struct Section
     Section& addByte(uint8_t b)
     {
         data.push_back(b);
-        pc++;
+        pc = pc.value() + 1;
         return *this;
     }
 
@@ -98,15 +98,15 @@ struct Section
 
     int32_t get_size() const
     {
-        return size >= 0 ? size : (int32_t)data.size();
+        return size >= 0 ? size.value() : (int32_t)data.size();
     }
 
     std::string name;
     std::string parent;
     std::vector<std::string> children;
-    int32_t start = -1;
-    int32_t pc = -1;
-    int32_t size = -1;
+    Optional<int32_t> start = -1;
+    Optional<int32_t> pc = -1;
+    Optional<int32_t> size = -1;
     uint32_t flags{};
     std::vector<uint8_t> data;
     bool valid{true};
@@ -129,7 +129,7 @@ public:
 
     void clear();
 
-    int32_t layoutSection(int32_t start, Section& s);
+    int32_t layoutSection(Optional<int32_t> const& o_start, Section& s);
     bool layoutSections();
     Error checkOverlap();
 

--- a/src/machine.h
+++ b/src/machine.h
@@ -104,7 +104,7 @@ struct Section
     std::string name;
     std::string parent;
     std::vector<std::string> children;
-    Optional<int32_t> start = -1;
+    Optional<int32_t> start;
     Optional<int32_t> pc = -1;
     Optional<int32_t> size = -1;
     uint32_t flags{};

--- a/src/machine.h
+++ b/src/machine.h
@@ -129,7 +129,7 @@ public:
 
     void clear();
 
-    int32_t layoutSection(Optional<int32_t> const& o_start, Section& s);
+    int32_t layoutSection(int32_t start, Section& s);
     bool layoutSections();
     Error checkOverlap();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -238,9 +238,9 @@ int main(int argc, char** argv)
         int32_t start = 0x10000;
         for (auto const& s : mach.getSections()) {
             if (!s.data.empty() && (s.flags & NoStorage) == 0) {
-                emu.load(s.start, s.data);
+                emu.load(s.start.value(), s.data);
                 if (s.start < start) {
-                    start = s.start;
+                    start = s.start.value();
                 }
             }
         }
@@ -292,8 +292,8 @@ int main(int argc, char** argv)
         mach.sortSectionsByStart();
         for (auto const& section : mach.getSections()) {
             if (!section.data.empty()) {
-                fmt::print("{:04x}-{:04x} {}\n", section.start,
-                           section.start + section.data.size()-1, section.name);
+                fmt::print("{:04x}-{:04x} {}\n", section.start.value(),
+                           section.start.value() + section.data.size()-1, section.name);
             }
         }
     }

--- a/src/symbol_table.h
+++ b/src/symbol_table.h
@@ -160,6 +160,10 @@ public:
     template <typename T>
     void set(std::string const& name, T const& val)
     {
+        // TODO: cannot check on optional template types (check the ones we use explicitly)
+        static_assert(false == std::is_same_v<Optional<int32_t>, T>);
+        static_assert(false == std::is_same_v<Optional<Number>, T>);
+
         if (!is_redefinable(name)) {
             throw sym_error(fmt::format("Symbol '{}' already defined", name));
         }


### PR DESCRIPTION
The basic idea is to enable bass's `SymbolTable` to interpret `nullopt` (aka "undefined", "None" or "nil") for typed arguments.
Currently such state does not exist (which in worst case can result in output holding "false positive" bytes - e.g. `0xff` sometimes means -1 and sometimes it should error out instead - :zap:)

Addressing section "start", "pc" and "size" as a starting point.

**To keep changes reviewable the logical behaviour of the assembler does not change here (at least not yet). What changes is only the comparison `section.start == -1` vs `!section.start.has_value()` (alternatively `section.start == std::nullopt`).**