### PR TITLE
Rename "sections.{name}" prefix to "section.{name}"

### DIFF
--- a/src/meta.cpp
+++ b/src/meta.cpp
@@ -429,7 +429,7 @@ void initMeta(Assembler& assem)
             }
 
 
-            auto p = "sections."s + std::string(section.name);
+            auto p = "section."s + std::string(section.name);
             if ((section.flags & Compressed) != 0) {
                 LOGI("Packing %s", p.c_str());
                 std::vector<uint8_t> packed(0x10000);

--- a/tests/sections.asm
+++ b/tests/sections.asm
@@ -37,5 +37,5 @@ yo:
 }
 
 last:
-    !fill sections.funky.data
+    !fill section.funky.data
 


### PR DESCRIPTION
Is it a typo?